### PR TITLE
add markdown to Words

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.6.0",
         "json-schema-to-typescript": "^13.1.2",
+        "markdown-to-jsx": "^7.4.7",
         "react": "18.2.0",
         "react-devtools": "^5.0.0",
         "react-dom": "18.2.0",
@@ -16060,6 +16061,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.7.tgz",
+      "integrity": "sha512-0+ls1IQZdU6cwM1yu0ZjjiVWYtkbExSyUIFU2ZeDIFuZM1W42Mh4OlJ4nb4apX4H8smxDHRdFaoIVJGwfv5hkg==",
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
       }
     },
     "node_modules/marky": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.6.0",
     "json-schema-to-typescript": "^13.1.2",
+    "markdown-to-jsx": "^7.4.7",
     "react": "18.2.0",
     "react-devtools": "^5.0.0",
     "react-dom": "18.2.0",

--- a/src/ui/atoms/words.tsx
+++ b/src/ui/atoms/words.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Text, StyleSheet, StyleProp, TextStyle } from 'react-native';
 import { useTheme, Theme, FontTag } from '@/ui/theme';
+import Markdown from 'markdown-to-jsx';
 
 interface WordsProps {
   tag: FontTag;
@@ -21,7 +22,19 @@ const Words: React.FC<WordsProps> = ({ tag, children, style, alt, button }) => {
 
   const styles = getStyles(theme, tag, alt, button);
 
-  return <Text style={[styles.font, styles.color, style]}>{children}</Text>;
+  // Ensure children is a string for Markdown component
+  const isString = typeof children === 'string';
+  const childrenString = isString ? children : '';
+
+  if (isString) {
+    return (
+      <Text style={[styles.font, styles.color, style]}>
+        <Markdown>{childrenString}</Markdown>
+      </Text>
+    );
+  } else {
+    return <Text style={[styles.font, styles.color, style]}>children</Text>;
+  }
 };
 
 const getColor = (


### PR DESCRIPTION
Compared this `markdown-to-jsx` with react-markdown the leading two AI recommendations, validated on google. Has a fair number of github stars (1.9k), prides itself in being the good lightweight choice.  A few others had less advantageous syntax. than `<markdown>content</markdown>`

The extra code was to fix a type error in the code that said the children property might not be a string. My default was to maintain original functionality if the WordsProp `children` might not be a string. Unsure what cases that would be true in.